### PR TITLE
Stabilize ledger ID generation without crypto entropy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Run tests
+        run: go test ./...
+      - name: Run go vet
+        run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+/tmp/
+*.log
+web/node_modules/
+web/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download || true
+
+COPY . .
+RUN go build -o server ./cmd/server
+
+FROM alpine:3.20
+
+WORKDIR /app
+
+COPY --from=builder /app/server /usr/local/bin/server
+COPY migrations ./migrations
+COPY openapi.yaml ./openapi.yaml
+
+ENV GIN_MODE=release
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/server"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build run migrate test
+
+build:
+	mkdir -p bin
+	go build -o bin/server ./cmd/server
+
+run:
+	go run ./cmd/server
+
+migrate:
+	@echo "Run database migrations here"
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
-# RoundOneLeger
-ST Leger 
+# Ledger Platform
+
+This repository contains a self-contained asset ledger backend written in Go. It exposes a REST API for device/IP/personnel/system management, supports public-key based authentication, enforces IP allowlists, provides undo/redo history, and can import/export Excel workbooks that describe the ledgers individually or as a Cartesian matrix.
+
+## Features
+
+- **Authentication** – Ed25519 enrollment/login flows that bind users to browser/device fingerprints and issue bearer tokens.
+- **Ledger management** – CRUD endpoints for IPs, devices, personnel, and systems with tagging, ordering, and cross-linking.
+- **Excel workflows** – Import/export XLSX workbooks with automatic IP column detection and a derived matrix sheet representing all combinations.
+- **Undo/redo** – Ten-level history stack for manual corrections across all ledgers.
+- **Audit log chain** – Tamper-evident audit trail with verification endpoint.
+- **IP allowlist** – CIDR-aware middleware that blocks requests from unapproved addresses.
+- **In-memory implementation** – Runs without external services by default; optional PostgreSQL connection helpers and SQL migrations are included for production rollout.
+
+## Project Layout
+
+```
+cmd/server            # Application entrypoint
+internal/api          # HTTP handlers and routing
+internal/auth         # Session token manager
+internal/db           # Database connectivity helper
+internal/middleware   # Shared middleware (auth, IP checks)
+internal/models       # Ledger store, auth, audit, allowlist logic
+internal/xlsx         # XLSX encoder/decoder used for import/export
+migrations            # PostgreSQL schema bootstrap
+openapi.yaml          # OpenAPI 3 definition of the REST API
+third_party/gin       # Minimal Gin-compatible shim (no external deps)
+web/                  # Frontend placeholder (not required to run backend)
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.22+
+- (Optional) PostgreSQL 15+ if you plan to run migrations
+- Docker & Docker Compose if you prefer container-based workflows
+
+### Environment Variables
+
+| Variable             | Default     | Description                                      |
+|----------------------|-------------|--------------------------------------------------|
+| `DB_HOST`            | `localhost` | PostgreSQL host                                  |
+| `DB_PORT`            | `5432`      | PostgreSQL port                                  |
+| `DB_NAME`            | `ledger`    | PostgreSQL database name                         |
+| `DB_USER`            | `postgres`  | PostgreSQL user                                  |
+| `DB_PASS`            | `postgres`  | PostgreSQL password                              |
+| `FINGERPRINT_SECRET` | random      | HMAC secret for fingerprint hashing (optional)   |
+
+### Local Development
+
+```bash
+make build   # Compile the server into ./bin/server
+make run     # Start the HTTP server on :8080
+make test    # Run Go unit tests
+make migrate # Placeholder: run migrations with your preferred tool
+```
+
+When the server is running, open <http://localhost:8080/health> to confirm it is healthy. The endpoint returns additional database status details if a PostgreSQL server is reachable.
+
+### Docker Compose
+
+The provided `docker-compose.yml` launches PostgreSQL and the Go API in a single command:
+
+```bash
+docker-compose up --build
+```
+
+Once both containers are healthy, the API is reachable at <http://localhost:8080> with identical routes as the local build.
+
+## Authentication Flow
+
+1. **Enrollment Request** – POST `/auth/enroll-request` with `{username, device_name, public_key}` (Ed25519 public key base64). The server issues a `device_id` and `nonce`.
+2. **Enrollment Complete** – POST `/auth/enroll-complete` with `{username, device_id, nonce, signature, fingerprint}` where `signature` is over the nonce and `fingerprint` is a client-generated descriptor. The server stores the fingerprint hash.
+3. **Request Login Nonce** – POST `/auth/request-nonce` to fetch a short-lived nonce for the device.
+4. **Login** – POST `/auth/login` with `{username, device_id, nonce, signature, fingerprint}`. Successful validation issues a bearer token used in the `Authorization: Bearer <token>` header for subsequent requests.
+
+See `openapi.yaml` for complete request/response schemas and error codes.
+
+## Ledgers & Excel Import/Export
+
+- `GET /api/v1/ledgers/{type}` – Retrieve ledger entries (`type` = `ips`, `devices`, `personnel`, or `systems`).
+- `POST /api/v1/ledgers/{type}` / `PUT` / `DELETE` – Manage entries with tags, attributes, and cross-ledger links.
+- `POST /api/v1/ledgers/{type}/reorder` – Persist manual ordering (drag/drop style).
+- `POST /api/v1/ledgers/{type}/import` – Provide a base64-encoded XLSX snippet to replace a single ledger. IP columns are auto-detected via regex even if headers are missing.
+- `GET /api/v1/ledgers/export` – Download a multi-sheet workbook containing individual ledgers and a `Matrix` sheet that renders every linked combination (Cartesian product) of IP → Device → Personnel → System.
+- `POST /api/v1/ledgers/import` – Replace all ledgers using a multi-sheet workbook.
+
+## History & Audit
+
+- `POST /api/v1/history/undo` / `redo` – Walk backward/forward up to ten steps.
+- `GET /api/v1/history` – Returns undo/redo availability flags.
+- `GET /api/v1/audit` – Fetch tamper-evident audit logs.
+- `GET /api/v1/audit/verify` – Recomputes the audit hash chain for integrity checking.
+
+## Testing
+
+Run the suite locally:
+
+```bash
+go test ./...
+```
+
+The tests exercise the ledger store, authentication flow, XLSX codec, and matrix export logic to ensure the critical features remain functional.
+
+## Migrations
+
+The `migrations/0001_init.sql` script creates PostgreSQL tables for users, devices, allowlists, and audit logs, and seeds an `admin` account. Apply it with your preferred migration tool before switching the store implementation to a database-backed version.
+
+## API Reference
+
+Browse `openapi.yaml` or load it into Swagger UI/Postman to explore all routes, schemas, and example payloads.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"ledger/internal/api"
+	"ledger/internal/auth"
+	"ledger/internal/db"
+	"ledger/internal/models"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	database, err := db.ConnectFromEnv(ctx)
+	if err != nil {
+		log.Printf("database connection warning: %v", err)
+	}
+
+	if database != nil {
+		defer func() {
+			if err := database.Close(); err != nil {
+				log.Printf("database close error: %v", err)
+			}
+		}()
+	}
+
+	fingerprintSecret := []byte(os.Getenv("FINGERPRINT_SECRET"))
+	store := models.NewLedgerStore(fingerprintSecret)
+	sessions := auth.NewManager(12 * time.Hour)
+
+	router := api.NewRouter(api.Config{Database: database, Store: store, Sessions: sessions})
+
+	srv := &http.Server{
+		Addr:              ":8080",
+		Handler:           router,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server failed: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("server shutdown error: %v", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ledger
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d ledger"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: ledger
+      DB_USER: postgres
+      DB_PASS: postgres
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module ledger
+
+go 1.22
+
+require github.com/gin-gonic/gin v0.0.0
+
+replace github.com/gin-gonic/gin => ./third_party/gin

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"ledger/internal/auth"
+	"ledger/internal/db"
+	"ledger/internal/models"
+)
+
+// Config configures the router dependencies.
+type Config struct {
+	Database *db.Database
+	Store    *models.LedgerStore
+	Sessions *auth.Manager
+}
+
+// NewRouter configures HTTP routes for the application.
+func NewRouter(cfg Config) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Recovery(), gin.Logger())
+
+	server := &Server{Database: cfg.Database, Store: cfg.Store, Sessions: cfg.Sessions}
+	server.RegisterRoutes(r)
+
+	return r
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,730 @@
+package api
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"ledger/internal/auth"
+	"ledger/internal/db"
+	"ledger/internal/middleware"
+	"ledger/internal/models"
+	"ledger/internal/xlsx"
+)
+
+// Server wires handlers to the in-memory store and session manager.
+type Server struct {
+	Database *db.Database
+	Store    *models.LedgerStore
+	Sessions *auth.Manager
+}
+
+// RegisterRoutes attaches handlers to the gin engine.
+func (s *Server) RegisterRoutes(router *gin.Engine) {
+	router.GET("/health", s.handleHealth)
+
+	authGroup := router.Group("/auth")
+	{
+		authGroup.POST("/enroll-request", s.handleEnrollRequest)
+		authGroup.POST("/enroll-complete", s.handleEnrollComplete)
+		authGroup.POST("/request-nonce", s.handleRequestNonce)
+		authGroup.POST("/login", s.handleLogin)
+	}
+
+	secured := router.Group("/api/v1")
+	secured.Use(middleware.RequireSession(s.Sessions))
+	{
+		secured.GET("/ledgers/:type", s.handleListLedger)
+		secured.POST("/ledgers/:type", s.handleCreateLedger)
+		secured.PUT("/ledgers/:type/:id", s.handleUpdateLedger)
+		secured.DELETE("/ledgers/:type/:id", s.handleDeleteLedger)
+		secured.POST("/ledgers/:type/reorder", s.handleReorderLedger)
+		secured.POST("/ledgers/:type/import", s.handleImportLedger)
+		secured.GET("/ledgers/export", s.handleExportLedger)
+		secured.POST("/ledgers/import", s.handleImportWorkbook)
+		secured.GET("/ledger-cartesian", s.handleLedgerMatrix)
+
+		secured.GET("/ip-allowlist", s.handleListAllowlist)
+		secured.POST("/ip-allowlist", s.handleCreateAllowlist)
+		secured.PUT("/ip-allowlist/:id", s.handleUpdateAllowlist)
+		secured.DELETE("/ip-allowlist/:id", s.handleDeleteAllowlist)
+
+		secured.POST("/history/undo", s.handleUndo)
+		secured.POST("/history/redo", s.handleRedo)
+		secured.GET("/history", s.handleHistoryStatus)
+
+		secured.GET("/audit", s.handleAuditList)
+		secured.GET("/audit/verify", s.handleAuditVerify)
+	}
+}
+
+func (s *Server) handleHealth(c *gin.Context) {
+	payload := gin.H{"status": "ok", "timestamp": time.Now().UTC().Format(time.RFC3339)}
+	if s.Database != nil {
+		if err := s.Database.PingContext(c.Request.Context()); err != nil {
+			payload["database"] = gin.H{"status": "unavailable", "error": err.Error()}
+		} else {
+			payload["database"] = gin.H{"status": "ok"}
+		}
+	}
+	c.JSON(http.StatusOK, payload)
+}
+
+type enrollRequest struct {
+	Username   string `json:"username"`
+	DeviceName string `json:"device_name"`
+	PublicKey  string `json:"public_key"`
+}
+
+type enrollResponse struct {
+	DeviceID string `json:"device_id"`
+	Nonce    string `json:"nonce"`
+}
+
+func (s *Server) handleEnrollRequest(c *gin.Context) {
+	var req enrollRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	key, err := base64.RawStdEncoding.DecodeString(req.PublicKey)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_public_key"})
+		return
+	}
+	enrollment, err := s.Store.StartEnrollment(req.Username, req.DeviceName, key)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, enrollResponse{DeviceID: enrollment.DeviceID, Nonce: enrollment.Nonce})
+}
+
+type enrollCompleteRequest struct {
+	Username    string `json:"username"`
+	DeviceID    string `json:"device_id"`
+	Nonce       string `json:"nonce"`
+	Signature   string `json:"signature"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+func (s *Server) handleEnrollComplete(c *gin.Context) {
+	var req enrollCompleteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	sig, err := base64.RawStdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_signature"})
+		return
+	}
+	device, err := s.Store.CompleteEnrollment(req.Username, req.DeviceID, req.Nonce, sig, req.Fingerprint)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"device_id": device.ID, "fingerprint_sum": device.FingerprintSum})
+}
+
+type nonceRequest struct {
+	Username string `json:"username"`
+	DeviceID string `json:"device_id"`
+}
+
+type nonceResponse struct {
+	Nonce string `json:"nonce"`
+}
+
+func (s *Server) handleRequestNonce(c *gin.Context) {
+	var req nonceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	challenge, err := s.Store.RequestLoginNonce(req.Username, req.DeviceID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, nonceResponse{Nonce: challenge.Nonce})
+}
+
+type loginRequest struct {
+	Username    string `json:"username"`
+	DeviceID    string `json:"device_id"`
+	Nonce       string `json:"nonce"`
+	Signature   string `json:"signature"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+func (s *Server) handleLogin(c *gin.Context) {
+	var req loginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	sig, err := base64.RawStdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_signature"})
+		return
+	}
+	ip := clientIP(c.Request)
+	if _, err := s.Store.ValidateLogin(req.Username, req.DeviceID, req.Nonce, sig, req.Fingerprint, ip); err != nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	session, err := s.Sessions.Issue(strings.ToLower(req.Username), req.DeviceID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "session_issue_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, session)
+}
+
+func clientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if v := r.Header.Get("X-Forwarded-For"); v != "" {
+		parts := strings.Split(v, ",")
+		return strings.TrimSpace(parts[0])
+	}
+	host := r.RemoteAddr
+	if strings.Contains(host, ":") {
+		host, _, _ = strings.Cut(host, ":")
+	}
+	return host
+}
+
+func (s *Server) handleListLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	entries := s.Store.ListEntries(typ)
+	c.JSON(http.StatusOK, gin.H{"items": entries})
+}
+
+type ledgerRequest struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Attributes  map[string]string   `json:"attributes"`
+	Tags        []string            `json:"tags"`
+	Links       map[string][]string `json:"links"`
+}
+
+func (s *Server) handleCreateLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	var req ledgerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	entry := models.LedgerEntry{
+		Name:        req.Name,
+		Description: req.Description,
+		Attributes:  req.Attributes,
+		Tags:        req.Tags,
+		Links:       convertLinks(req.Links),
+	}
+	session := currentSession(c, s.Sessions)
+	created, err := s.Store.CreateEntry(typ, entry, session)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, created)
+}
+
+func convertLinks(input map[string][]string) map[models.LedgerType][]string {
+	if input == nil {
+		return nil
+	}
+	out := make(map[models.LedgerType][]string, len(input))
+	for key, values := range input {
+		if typ, ok := parseLedgerType(key); ok {
+			out[typ] = append([]string{}, values...)
+		}
+	}
+	return out
+}
+
+func (s *Server) handleUpdateLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	var req ledgerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	session := currentSession(c, s.Sessions)
+	updated, err := s.Store.UpdateEntry(typ, c.Param("id"), models.LedgerEntry{
+		Name:        req.Name,
+		Description: req.Description,
+		Attributes:  req.Attributes,
+		Tags:        req.Tags,
+		Links:       convertLinks(req.Links),
+	}, session)
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, models.ErrEntryNotFound) {
+			status = http.StatusNotFound
+		}
+		c.AbortWithStatusJSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}
+
+func (s *Server) handleDeleteLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	session := currentSession(c, s.Sessions)
+	if err := s.Store.DeleteEntry(typ, c.Param("id"), session); err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, models.ErrEntryNotFound) {
+			status = http.StatusNotFound
+		}
+		c.AbortWithStatusJSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+type reorderRequest struct {
+	IDs []string `json:"ids"`
+}
+
+func (s *Server) handleReorderLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	var req reorderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	session := currentSession(c, s.Sessions)
+	entries, err := s.Store.ReorderEntries(typ, req.IDs, session)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": entries})
+}
+
+type importRequest struct {
+	Data string `json:"data"`
+}
+
+func (s *Server) handleImportLedger(c *gin.Context) {
+	typ, ok := parseLedgerType(c.Param("type"))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "unknown_ledger"})
+		return
+	}
+	var req importRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_base64"})
+		return
+	}
+	workbook, err := xlsx.Decode(raw)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_workbook"})
+		return
+	}
+	sheetName := sheetNameForType(typ)
+	sheet, ok := workbook.SheetByName(sheetName)
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "sheet_missing"})
+		return
+	}
+	entries := parseLedgerSheet(typ, sheet)
+	session := currentSession(c, s.Sessions)
+	s.Store.ReplaceEntries(typ, entries, session)
+	c.JSON(http.StatusOK, gin.H{"items": s.Store.ListEntries(typ)})
+}
+
+var ipRegex = regexp.MustCompile(`(?i)^(?:\d{1,3}\.){3}\d{1,3}$|^(?:[a-f0-9]{0,4}:){2,7}[a-f0-9]{0,4}$`)
+
+func parseLedgerSheet(typ models.LedgerType, sheet xlsx.Sheet) []models.LedgerEntry {
+	if len(sheet.Rows) == 0 {
+		return nil
+	}
+	headers := normaliseHeaders(sheet.Rows[0])
+	entries := make([]models.LedgerEntry, 0, len(sheet.Rows)-1)
+	for _, row := range sheet.Rows[1:] {
+		if len(row) == 0 {
+			continue
+		}
+		entry := models.LedgerEntry{Attributes: map[string]string{}, Links: map[models.LedgerType][]string{}}
+		for idx, header := range headers {
+			if idx >= len(row) {
+				continue
+			}
+			value := strings.TrimSpace(row[idx])
+			switch header {
+			case "id":
+				entry.ID = value
+			case "name":
+				entry.Name = value
+			case "description":
+				entry.Description = value
+			case "tags":
+				entry.Tags = strings.Split(value, ";")
+			default:
+				if header == "" {
+					if typ == models.LedgerTypeIP && ipRegex.MatchString(value) {
+						entry.Attributes["address"] = value
+						if entry.Name == "" {
+							entry.Name = value
+						}
+					}
+					continue
+				}
+				if strings.HasPrefix(header, "link_") {
+					if typ, ok := parseLedgerType(strings.TrimPrefix(header, "link_")); ok {
+						entry.Links[typ] = strings.FieldsFunc(value, func(r rune) bool { return r == ';' || r == ',' })
+					}
+					continue
+				}
+				if entry.Attributes == nil {
+					entry.Attributes = make(map[string]string)
+				}
+				entry.Attributes[header] = value
+			}
+		}
+		if typ == models.LedgerTypeIP && entry.Name == "" {
+			if addr := entry.Attributes["address"]; addr != "" {
+				entry.Name = addr
+			}
+		}
+		if entry.ID == "" {
+			entry.ID = models.GenerateID(string(typ))
+		}
+		entry.CreatedAt = time.Now().UTC()
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func normaliseHeaders(headers []string) []string {
+	out := make([]string, len(headers))
+	for i, header := range headers {
+		h := strings.TrimSpace(strings.ToLower(header))
+		out[i] = h
+	}
+	return out
+}
+
+func (s *Server) handleExportLedger(c *gin.Context) {
+	workbook := s.buildWorkbook()
+	data, err := xlsx.Encode(workbook)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "export_failed"})
+		return
+	}
+	c.Writer.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	c.Writer.Header().Set("Content-Disposition", "attachment; filename=ledger.xlsx")
+	_, _ = c.Writer.Write(data)
+}
+
+func (s *Server) handleImportWorkbook(c *gin.Context) {
+	var req importRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_base64"})
+		return
+	}
+	workbook, err := xlsx.Decode(raw)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_workbook"})
+		return
+	}
+	session := currentSession(c, s.Sessions)
+	for _, typ := range models.AllLedgerTypes {
+		sheetName := sheetNameForType(typ)
+		if sheet, ok := workbook.SheetByName(sheetName); ok {
+			entries := parseLedgerSheet(typ, sheet)
+			s.Store.ReplaceEntries(typ, entries, session)
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "imported"})
+}
+
+func (s *Server) handleLedgerMatrix(c *gin.Context) {
+	matrix := s.buildCartesianRows()
+	c.JSON(http.StatusOK, gin.H{"rows": matrix})
+}
+
+func (s *Server) handleListAllowlist(c *gin.Context) {
+	entries := s.Store.ListAllowlist()
+	c.JSON(http.StatusOK, gin.H{"items": entries})
+}
+
+type allowRequest struct {
+	Label       string `json:"label"`
+	CIDR        string `json:"cidr"`
+	Description string `json:"description"`
+}
+
+func (s *Server) handleCreateAllowlist(c *gin.Context) {
+	var req allowRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	entry, err := s.Store.AppendAllowlist(&models.IPAllowlistEntry{Label: req.Label, CIDR: req.CIDR, Description: req.Description}, currentSession(c, s.Sessions))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, entry)
+}
+
+func (s *Server) handleUpdateAllowlist(c *gin.Context) {
+	var req allowRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid_payload"})
+		return
+	}
+	entry := &models.IPAllowlistEntry{ID: c.Param("id"), Label: req.Label, CIDR: req.CIDR, Description: req.Description}
+	updated, err := s.Store.AppendAllowlist(entry, currentSession(c, s.Sessions))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}
+
+func (s *Server) handleDeleteAllowlist(c *gin.Context) {
+	if !s.Store.RemoveAllowlist(c.Param("id"), currentSession(c, s.Sessions)) {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (s *Server) handleUndo(c *gin.Context) {
+	if err := s.Store.Undo(); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (s *Server) handleRedo(c *gin.Context) {
+	if err := s.Store.Redo(); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (s *Server) handleHistoryStatus(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"undo": s.Store.CanUndo(), "redo": s.Store.CanRedo()})
+}
+
+func (s *Server) handleAuditList(c *gin.Context) {
+	audits := s.Store.ListAudits()
+	c.JSON(http.StatusOK, gin.H{"items": audits})
+}
+
+func (s *Server) handleAuditVerify(c *gin.Context) {
+	ok := s.Store.VerifyAuditChain()
+	c.JSON(http.StatusOK, gin.H{"verified": ok})
+}
+
+func parseLedgerType(value string) (models.LedgerType, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "ips", "ip":
+		return models.LedgerTypeIP, true
+	case "devices", "device":
+		return models.LedgerTypeDevice, true
+	case "personnel", "people", "person":
+		return models.LedgerTypePersonnel, true
+	case "systems", "system":
+		return models.LedgerTypeSystem, true
+	default:
+		return "", false
+	}
+}
+
+func currentSession(c *gin.Context, manager *auth.Manager) string {
+	if c == nil {
+		return "system"
+	}
+	if sessionAny, ok := c.Get(middleware.ContextSessionKey); ok {
+		if session, ok := sessionAny.(*auth.Session); ok {
+			return session.Username
+		}
+	}
+	return "system"
+}
+
+func (s *Server) buildWorkbook() xlsx.Workbook {
+	sheets := make([]xlsx.Sheet, 0, len(models.AllLedgerTypes)+1)
+	for _, typ := range models.AllLedgerTypes {
+		entries := s.Store.ListEntries(typ)
+		sheet := xlsx.Sheet{Name: sheetNameForType(typ)}
+		header := []string{"ID", "Name", "Description", "Tags"}
+		keys := attributeKeys(entries)
+		header = append(header, keys...)
+		for _, other := range models.AllLedgerTypes {
+			if other == typ {
+				continue
+			}
+			header = append(header, "link_"+string(other))
+		}
+		sheet.Rows = append(sheet.Rows, header)
+		for _, entry := range entries {
+			row := []string{entry.ID, entry.Name, entry.Description, strings.Join(entry.Tags, ";")}
+			for _, key := range keys {
+				row = append(row, entry.Attributes[key])
+			}
+			for _, other := range models.AllLedgerTypes {
+				if other == typ {
+					continue
+				}
+				row = append(row, strings.Join(entry.Links[other], ";"))
+			}
+			sheet.Rows = append(sheet.Rows, row)
+		}
+		sheets = append(sheets, sheet)
+	}
+	combined := s.buildCartesianRows()
+	matrixSheet := xlsx.Sheet{Name: "Matrix"}
+	matrixHeader := []string{"IP", "Device", "Personnel", "System"}
+	matrixSheet.Rows = append(matrixSheet.Rows, matrixHeader)
+	matrixSheet.Rows = append(matrixSheet.Rows, combined...)
+	sheets = append(sheets, matrixSheet)
+	workbook := xlsx.Workbook{Sheets: sheets}
+	workbook.SortSheets([]string{"IP", "Device", "Personnel", "System", "Matrix"})
+	return workbook
+}
+
+func attributeKeys(entries []models.LedgerEntry) []string {
+	keysMap := make(map[string]struct{})
+	for _, entry := range entries {
+		for key := range entry.Attributes {
+			keysMap[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(keysMap))
+	for key := range keysMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *Server) buildCartesianRows() [][]string {
+	ips := s.Store.ListEntries(models.LedgerTypeIP)
+	devices := s.Store.ListEntries(models.LedgerTypeDevice)
+	personnel := s.Store.ListEntries(models.LedgerTypePersonnel)
+	systems := s.Store.ListEntries(models.LedgerTypeSystem)
+
+	rows := [][]string{}
+	for _, device := range devices {
+		linkedIPs := uniqueOrAll(device.Links[models.LedgerTypeIP], ips)
+		linkedPersonnel := uniqueOrAll(device.Links[models.LedgerTypePersonnel], personnel)
+		linkedSystems := uniqueOrAll(device.Links[models.LedgerTypeSystem], systems)
+		for _, ipID := range linkedIPs {
+			ipName := lookupName(ipID, ips)
+			for _, personID := range linkedPersonnel {
+				personName := lookupName(personID, personnel)
+				for _, systemID := range linkedSystems {
+					systemName := lookupName(systemID, systems)
+					rows = append(rows, []string{ipName, device.Name, personName, systemName})
+				}
+			}
+		}
+	}
+	if len(rows) == 0 {
+		rows = append(rows, []string{"", "", "", ""})
+	}
+	return rows
+}
+
+func uniqueOrAll(ids []string, entries []models.LedgerEntry) []string {
+	if len(ids) == 0 {
+		out := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			out = append(out, entry.ID)
+		}
+		return out
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		for _, entry := range entries {
+			out = append(out, entry.ID)
+		}
+	}
+	return out
+}
+
+func lookupName(id string, entries []models.LedgerEntry) string {
+	for _, entry := range entries {
+		if entry.ID == id {
+			return entry.Name
+		}
+	}
+	return id
+}
+
+func sheetNameForType(typ models.LedgerType) string {
+	switch typ {
+	case models.LedgerTypeIP:
+		return "IP"
+	case models.LedgerTypeDevice:
+		return "Device"
+	case models.LedgerTypePersonnel:
+		return "Personnel"
+	case models.LedgerTypeSystem:
+		return "System"
+	default:
+		return strings.Title(string(typ))
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"testing"
+
+	"ledger/internal/models"
+	"ledger/internal/xlsx"
+)
+
+func TestParseLedgerSheetDetectsIP(t *testing.T) {
+	sheet := xlsx.Sheet{
+		Name: "IP",
+		Rows: [][]string{
+			{"", ""},
+			{"", "192.168.0.10"},
+		},
+	}
+	entries := parseLedgerSheet(models.LedgerTypeIP, sheet)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Attributes["address"] != "192.168.0.10" {
+		t.Fatalf("expected address attribute to be detected")
+	}
+	if entries[0].Name != "192.168.0.10" {
+		t.Fatalf("expected entry name to default to IP value, got %s", entries[0].Name)
+	}
+}
+
+func TestBuildCartesianRows(t *testing.T) {
+	store := models.NewLedgerStore([]byte("secret"))
+	ip, err := store.CreateEntry(models.LedgerTypeIP, models.LedgerEntry{Name: "Gateway IP"}, "tester")
+	if err != nil {
+		t.Fatalf("create ip: %v", err)
+	}
+	device, err := store.CreateEntry(models.LedgerTypeDevice, models.LedgerEntry{Name: "Firewall"}, "tester")
+	if err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+	person, err := store.CreateEntry(models.LedgerTypePersonnel, models.LedgerEntry{Name: "Alice"}, "tester")
+	if err != nil {
+		t.Fatalf("create personnel: %v", err)
+	}
+	system, err := store.CreateEntry(models.LedgerTypeSystem, models.LedgerEntry{Name: "ERP"}, "tester")
+	if err != nil {
+		t.Fatalf("create system: %v", err)
+	}
+	_, err = store.UpdateEntry(models.LedgerTypeDevice, device.ID, models.LedgerEntry{Links: map[models.LedgerType][]string{
+		models.LedgerTypeIP:        {ip.ID},
+		models.LedgerTypePersonnel: {person.ID},
+		models.LedgerTypeSystem:    {system.ID},
+	}}, "tester")
+	if err != nil {
+		t.Fatalf("update device links: %v", err)
+	}
+	server := &Server{Store: store}
+	rows := server.buildCartesianRows()
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	expected := []string{"Gateway IP", "Firewall", "Alice", "ERP"}
+	for i, value := range expected {
+		if rows[0][i] != value {
+			t.Fatalf("unexpected value at column %d: %s", i, rows[0][i])
+		}
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+// Session represents an issued login token.
+type Session struct {
+	Token     string    `json:"token"`
+	Username  string    `json:"username"`
+	DeviceID  string    `json:"device_id"`
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// Manager tracks active sessions in-memory.
+type Manager struct {
+	mu      sync.RWMutex
+	ttl     time.Duration
+	entries map[string]*Session
+}
+
+// NewManager constructs a session manager with the provided TTL.
+func NewManager(ttl time.Duration) *Manager {
+	if ttl <= 0 {
+		ttl = 12 * time.Hour
+	}
+	return &Manager{ttl: ttl, entries: make(map[string]*Session)}
+}
+
+// Issue creates a new session for a username and device.
+func (m *Manager) Issue(username, deviceID string) (*Session, error) {
+	token, err := randomToken()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	session := &Session{
+		Token:     token,
+		Username:  username,
+		DeviceID:  deviceID,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(m.ttl),
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[token] = session
+	return session, nil
+}
+
+// Validate looks up a token and returns the session if still valid.
+func (m *Manager) Validate(token string) (*Session, bool) {
+	m.mu.RLock()
+	session, ok := m.entries[token]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(session.ExpiresAt) {
+		m.Revoke(token)
+		return nil, false
+	}
+	return session, true
+}
+
+// Revoke removes a token from the manager.
+func (m *Manager) Revoke(token string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, token)
+}
+
+func randomToken() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+type Config struct {
+	Host     string
+	Port     string
+	Name     string
+	User     string
+	Password string
+}
+
+type Database struct {
+	cfg Config
+}
+
+func ConnectFromEnv(ctx context.Context) (*Database, error) {
+	database := &Database{cfg: loadConfigFromEnv()}
+	if err := database.PingContext(ctx); err != nil {
+		return database, fmt.Errorf("database ping failed: %w", err)
+	}
+	return database, nil
+}
+
+func (d *Database) DSN() string {
+	return fmt.Sprintf(
+		"host=%s port=%s dbname=%s user=%s password=%s sslmode=disable",
+		d.cfg.Host,
+		d.cfg.Port,
+		d.cfg.Name,
+		d.cfg.User,
+		d.cfg.Password,
+	)
+}
+
+func (d *Database) PingContext(ctx context.Context) error {
+	if d == nil {
+		return fmt.Errorf("database is not initialized")
+	}
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(d.cfg.Host, d.cfg.Port))
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func (d *Database) Close() error {
+	return nil
+}
+
+func loadConfigFromEnv() Config {
+	return Config{
+		Host:     getenv("DB_HOST", "localhost"),
+		Port:     getenv("DB_PORT", "5432"),
+		Name:     getenv("DB_NAME", "ledger"),
+		User:     getenv("DB_USER", "postgres"),
+		Password: getenv("DB_PASS", "postgres"),
+	}
+}
+
+func getenv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"ledger/internal/auth"
+	"ledger/internal/models"
+)
+
+const (
+	// ContextSessionKey stores the authenticated session on the Gin context.
+	ContextSessionKey = "ledger/session"
+)
+
+// IPAllowlist enforces allowlist membership using the provided store.
+func IPAllowlist(store *models.LedgerStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if store == nil {
+			c.Next()
+			return
+		}
+		ip := clientIP(c.Request)
+		if ip == "" || !store.IsIPAllowed(ip) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "ip_not_allowed"})
+			return
+		}
+		c.Next()
+	}
+}
+
+func clientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if v := r.Header.Get("X-Forwarded-For"); v != "" {
+		parts := strings.Split(v, ",")
+		candidate := strings.TrimSpace(parts[0])
+		if ip := net.ParseIP(candidate); ip != nil {
+			return ip.String()
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// RequireSession ensures a valid session token is provided via the Authorization header.
+func RequireSession(manager *auth.Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.GetHeader("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(header, prefix) {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing_token"})
+			return
+		}
+		token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+		session, ok := manager.Validate(token)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
+			return
+		}
+		c.Set(ContextSessionKey, session)
+		c.Next()
+	}
+}
+
+// OptionalSession attaches the session to the context if present but does not enforce authentication.
+func OptionalSession(manager *auth.Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.GetHeader("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(header, prefix) {
+			c.Next()
+			return
+		}
+		token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+		if session, ok := manager.Validate(token); ok {
+			c.Set(ContextSessionKey, session)
+		}
+		c.Next()
+	}
+}

--- a/internal/models/history.go
+++ b/internal/models/history.go
@@ -1,0 +1,62 @@
+package models
+
+type storeSnapshot struct {
+	entries map[LedgerType][]LedgerEntry
+}
+
+type historyStack struct {
+	states []storeSnapshot
+	future []storeSnapshot
+	limit  int
+}
+
+func (h *historyStack) Reset(snapshot storeSnapshot) {
+	h.states = []storeSnapshot{snapshot}
+	h.future = nil
+}
+
+func (h *historyStack) Push(snapshot storeSnapshot) {
+	h.states = append(h.states, snapshot)
+	if h.limit > 0 && len(h.states) > h.limit {
+		h.states = h.states[1:]
+	}
+	h.future = nil
+}
+
+func (h *historyStack) Current() storeSnapshot {
+	if len(h.states) == 0 {
+		return storeSnapshot{}
+	}
+	return h.states[len(h.states)-1]
+}
+
+func (h *historyStack) Undo() (storeSnapshot, error) {
+	if len(h.states) <= 1 {
+		return storeSnapshot{}, ErrUndoUnavailable
+	}
+	current := h.states[len(h.states)-1]
+	h.states = h.states[:len(h.states)-1]
+	h.future = append([]storeSnapshot{current}, h.future...)
+	return h.states[len(h.states)-1], nil
+}
+
+func (h *historyStack) Redo() (storeSnapshot, error) {
+	if len(h.future) == 0 {
+		return storeSnapshot{}, ErrRedoUnavailable
+	}
+	next := h.future[0]
+	h.future = h.future[1:]
+	h.states = append(h.states, next)
+	if h.limit > 0 && len(h.states) > h.limit {
+		h.states = h.states[1:]
+	}
+	return next, nil
+}
+
+func (h *historyStack) CanUndo() bool {
+	return len(h.states) > 1
+}
+
+func (h *historyStack) CanRedo() bool {
+	return len(h.future) > 0
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,108 @@
+package models
+
+import "time"
+
+// LedgerType represents the category of a ledger entry.
+type LedgerType string
+
+const (
+	LedgerTypeIP        LedgerType = "ips"
+	LedgerTypeDevice    LedgerType = "devices"
+	LedgerTypePersonnel LedgerType = "personnel"
+	LedgerTypeSystem    LedgerType = "systems"
+)
+
+// AllLedgerTypes lists the supported ledgers in a stable order.
+var AllLedgerTypes = []LedgerType{LedgerTypeIP, LedgerTypeDevice, LedgerTypePersonnel, LedgerTypeSystem}
+
+// LedgerEntry describes a single item within a ledger.
+type LedgerEntry struct {
+	ID          string                  `json:"id"`
+	Name        string                  `json:"name"`
+	Description string                  `json:"description,omitempty"`
+	Attributes  map[string]string       `json:"attributes,omitempty"`
+	Tags        []string                `json:"tags,omitempty"`
+	Links       map[LedgerType][]string `json:"links,omitempty"`
+	Order       int                     `json:"order"`
+	CreatedAt   time.Time               `json:"created_at"`
+	UpdatedAt   time.Time               `json:"updated_at"`
+}
+
+// Clone returns a deep copy of the entry.
+func (e LedgerEntry) Clone() LedgerEntry {
+	clone := e
+	if e.Attributes != nil {
+		clone.Attributes = make(map[string]string, len(e.Attributes))
+		for k, v := range e.Attributes {
+			clone.Attributes[k] = v
+		}
+	}
+	if e.Tags != nil {
+		clone.Tags = append([]string{}, e.Tags...)
+	}
+	if e.Links != nil {
+		clone.Links = make(map[LedgerType][]string, len(e.Links))
+		for t, ids := range e.Links {
+			clone.Links[t] = append([]string{}, ids...)
+		}
+	}
+	return clone
+}
+
+// IPAllowlistEntry represents a single CIDR or address allowed to access the system.
+type IPAllowlistEntry struct {
+	ID          string    `json:"id"`
+	Label       string    `json:"label"`
+	CIDR        string    `json:"cidr"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// AuditLogEntry represents a tamper evident log item.
+type AuditLogEntry struct {
+	ID        string    `json:"id"`
+	Actor     string    `json:"actor"`
+	Action    string    `json:"action"`
+	Details   string    `json:"details"`
+	Hash      string    `json:"hash"`
+	PrevHash  string    `json:"prev_hash"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// User represents an authenticated operator of the system.
+type User struct {
+	Username  string                 `json:"username"`
+	Devices   map[string]*UserDevice `json:"devices"`
+	Roles     []string               `json:"roles"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+// UserDevice represents a registered device bound to a user.
+type UserDevice struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	PublicKey      []byte    `json:"-"`
+	FingerprintSum string    `json:"fingerprint_sum"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// Enrollment describes an in-flight enrollment challenge.
+type Enrollment struct {
+	Username   string
+	DeviceID   string
+	DeviceName string
+	Nonce      string
+	PublicKey  []byte
+	CreatedAt  time.Time
+}
+
+// LoginChallenge stores a nonce waiting to be signed by a device.
+type LoginChallenge struct {
+	Username  string
+	DeviceID  string
+	Nonce     string
+	CreatedAt time.Time
+}

--- a/internal/models/store.go
+++ b/internal/models/store.go
@@ -1,0 +1,645 @@
+package models
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	mrand "math/rand"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrEntryNotFound is returned when a ledger entry cannot be located.
+	ErrEntryNotFound = errors.New("ledger entry not found")
+	// ErrUndoUnavailable indicates there is no further history to rewind.
+	ErrUndoUnavailable = errors.New("no undo steps available")
+	// ErrRedoUnavailable indicates there is no further forward history.
+	ErrRedoUnavailable = errors.New("no redo steps available")
+	// ErrEnrollmentNotFound indicates there is no pending enrollment for the provided identifiers.
+	ErrEnrollmentNotFound = errors.New("enrollment challenge not found")
+	// ErrLoginChallengeNotFound indicates there is no nonce to fulfil.
+	ErrLoginChallengeNotFound = errors.New("login challenge not found")
+	// ErrFingerprintMismatch occurs when the submitted fingerprint differs from the enrolled copy.
+	ErrFingerprintMismatch = errors.New("fingerprint mismatch")
+	// ErrSignatureInvalid indicates that signature verification failed.
+	ErrSignatureInvalid = errors.New("signature invalid")
+	// ErrIPNotAllowed indicates the source IP is not within the allowlist.
+	ErrIPNotAllowed = errors.New("ip not allowed")
+)
+
+var (
+	seededRand   = mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	seededRandMu sync.Mutex
+	idAlphabet   = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+)
+
+// LedgerStore coordinates all mutable state for the in-memory implementation.
+type LedgerStore struct {
+	mu sync.RWMutex
+
+	entries map[LedgerType][]LedgerEntry
+	allow   map[string]*IPAllowlistEntry
+	audits  []*AuditLogEntry
+	users   map[string]*User
+
+	pendingEnrollments map[string]*Enrollment
+	loginChallenges    map[string]*LoginChallenge
+
+	history historyStack
+
+	fingerprintSecret []byte
+}
+
+// NewLedgerStore constructs a ledger store with an optional fingerprint secret.
+func NewLedgerStore(secret []byte) *LedgerStore {
+	if len(secret) == 0 {
+		secret = make([]byte, 32)
+		if _, err := rand.Read(secret); err != nil {
+			secret = []byte("default-secret")
+		}
+	}
+	store := &LedgerStore{
+		entries:            make(map[LedgerType][]LedgerEntry),
+		allow:              make(map[string]*IPAllowlistEntry),
+		users:              make(map[string]*User),
+		pendingEnrollments: make(map[string]*Enrollment),
+		loginChallenges:    make(map[string]*LoginChallenge),
+		fingerprintSecret:  secret,
+	}
+	store.history.limit = 11
+	store.history.Reset(store.snapshotLocked())
+	return store
+}
+
+// helper to produce map key for pending enrollment login challenge.
+func enrollmentKey(username, deviceID string) string {
+	return fmt.Sprintf("%s:%s", strings.ToLower(username), deviceID)
+}
+
+// GenerateID creates a pseudo-random identifier string.
+func GenerateID(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, randomIDToken(18))
+}
+
+func randomIDToken(length int) string {
+	seededRandMu.Lock()
+	defer seededRandMu.Unlock()
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = idAlphabet[seededRand.Intn(len(idAlphabet))]
+	}
+	return string(b)
+}
+
+func cloneEntrySlice(entries []LedgerEntry) []LedgerEntry {
+	cloned := make([]LedgerEntry, len(entries))
+	for i, e := range entries {
+		cloned[i] = e.Clone()
+	}
+	return cloned
+}
+
+// recordSnapshotLocked must be called with the mutex locked.
+func (s *LedgerStore) snapshotLocked() storeSnapshot {
+	snapshot := storeSnapshot{entries: make(map[LedgerType][]LedgerEntry)}
+	for _, typ := range AllLedgerTypes {
+		if items, ok := s.entries[typ]; ok {
+			snapshot.entries[typ] = cloneEntrySlice(items)
+		}
+	}
+	return snapshot
+}
+
+func (s *LedgerStore) commitLocked() {
+	snapshot := s.snapshotLocked()
+	if len(s.history.states) == 0 {
+		s.history.Reset(snapshot)
+		return
+	}
+	s.history.Push(snapshot)
+}
+
+// ListEntries returns ordered entries for a ledger.
+func (s *LedgerStore) ListEntries(typ LedgerType) []LedgerEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entries := s.entries[typ]
+	cloned := make([]LedgerEntry, len(entries))
+	for i, e := range entries {
+		cloned[i] = e.Clone()
+	}
+	sort.Slice(cloned, func(i, j int) bool { return cloned[i].Order < cloned[j].Order })
+	return cloned
+}
+
+// GetEntry retrieves an entry by ID.
+func (s *LedgerStore) GetEntry(typ LedgerType, id string) (LedgerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.entries[typ] {
+		if e.ID == id {
+			return e.Clone(), nil
+		}
+	}
+	return LedgerEntry{}, ErrEntryNotFound
+}
+
+// CreateEntry appends a new entry to the ledger.
+func (s *LedgerStore) CreateEntry(typ LedgerType, entry LedgerEntry, actor string) (LedgerEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry.ID = GenerateID(string(typ))
+	entry.CreatedAt = time.Now().UTC()
+	entry.UpdatedAt = entry.CreatedAt
+	entry.Order = len(s.entries[typ])
+	entry.Tags = normaliseStrings(entry.Tags)
+	s.entries[typ] = append(s.entries[typ], entry.Clone())
+	s.appendAuditLocked(actor, fmt.Sprintf("create_%s", typ), entry.ID)
+	s.commitLocked()
+	return entry, nil
+}
+
+// UpdateEntry modifies the entry with matching ID.
+func (s *LedgerStore) UpdateEntry(typ LedgerType, id string, updates LedgerEntry, actor string) (LedgerEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := s.entries[typ]
+	for i, e := range items {
+		if e.ID == id {
+			updated := e.Clone()
+			if updates.Name != "" {
+				updated.Name = updates.Name
+			}
+			if updates.Description != "" {
+				updated.Description = updates.Description
+			}
+			if updates.Attributes != nil {
+				updated.Attributes = make(map[string]string, len(updates.Attributes))
+				for k, v := range updates.Attributes {
+					updated.Attributes[k] = v
+				}
+			}
+			if updates.Tags != nil {
+				updated.Tags = normaliseStrings(updates.Tags)
+			}
+			if updates.Links != nil {
+				updated.Links = make(map[LedgerType][]string, len(updates.Links))
+				for lt, ids := range updates.Links {
+					updated.Links[lt] = append([]string{}, ids...)
+				}
+			}
+			updated.UpdatedAt = time.Now().UTC()
+			items[i] = updated
+			s.entries[typ] = items
+			s.appendAuditLocked(actor, fmt.Sprintf("update_%s", typ), id)
+			s.commitLocked()
+			return updated.Clone(), nil
+		}
+	}
+	return LedgerEntry{}, ErrEntryNotFound
+}
+
+// DeleteEntry removes an entry and compacts ordering.
+func (s *LedgerStore) DeleteEntry(typ LedgerType, id string, actor string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := s.entries[typ]
+	for i, e := range items {
+		if e.ID == id {
+			items = append(items[:i], items[i+1:]...)
+			for idx := range items {
+				items[idx].Order = idx
+				items[idx].UpdatedAt = time.Now().UTC()
+			}
+			s.entries[typ] = items
+			s.appendAuditLocked(actor, fmt.Sprintf("delete_%s", typ), id)
+			s.commitLocked()
+			return nil
+		}
+	}
+	return ErrEntryNotFound
+}
+
+// ReorderEntries sets the ordering based on provided IDs. IDs not listed retain current order at end.
+func (s *LedgerStore) ReorderEntries(typ LedgerType, orderedIDs []string, actor string) ([]LedgerEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := s.entries[typ]
+	if len(items) == 0 {
+		return nil, nil
+	}
+	index := make(map[string]LedgerEntry, len(items))
+	for _, item := range items {
+		index[item.ID] = item
+	}
+
+	result := make([]LedgerEntry, 0, len(items))
+	seen := make(map[string]struct{}, len(orderedIDs))
+	for _, id := range orderedIDs {
+		if entry, ok := index[id]; ok {
+			seen[id] = struct{}{}
+			result = append(result, entry)
+		}
+	}
+	for _, item := range items {
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		result = append(result, item)
+	}
+	for i := range result {
+		result[i].Order = i
+		result[i].UpdatedAt = time.Now().UTC()
+	}
+	s.entries[typ] = result
+	s.appendAuditLocked(actor, fmt.Sprintf("reorder_%s", typ), strings.Join(orderedIDs, ","))
+	s.commitLocked()
+	out := make([]LedgerEntry, len(result))
+	for i, item := range result {
+		out[i] = item.Clone()
+	}
+	return out, nil
+}
+
+// ReplaceEntries overwrites the ledger with provided entries.
+func (s *LedgerStore) ReplaceEntries(typ LedgerType, entries []LedgerEntry, actor string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	normalized := make([]LedgerEntry, len(entries))
+	for i, entry := range entries {
+		entry.Order = i
+		entry.Tags = normaliseStrings(entry.Tags)
+		entry.CreatedAt = entry.CreatedAt.UTC()
+		entry.UpdatedAt = time.Now().UTC()
+		normalized[i] = entry.Clone()
+	}
+	s.entries[typ] = normalized
+	s.appendAuditLocked(actor, fmt.Sprintf("replace_%s", typ), fmt.Sprintf("count=%d", len(entries)))
+	s.commitLocked()
+}
+
+// Undo reverts the store to the previous snapshot.
+func (s *LedgerStore) Undo() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, err := s.history.Undo()
+	if err != nil {
+		return err
+	}
+	s.entries = cloneSnapshot(snapshot)
+	return nil
+}
+
+// Redo reapplies the next snapshot from history.
+func (s *LedgerStore) Redo() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, err := s.history.Redo()
+	if err != nil {
+		return err
+	}
+	s.entries = cloneSnapshot(snapshot)
+	return nil
+}
+
+// CanUndo reports whether history contains a previous snapshot.
+func (s *LedgerStore) CanUndo() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.history.CanUndo()
+}
+
+// CanRedo reports whether history contains a forward snapshot.
+func (s *LedgerStore) CanRedo() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.history.CanRedo()
+}
+
+func cloneSnapshot(snapshot storeSnapshot) map[LedgerType][]LedgerEntry {
+	cloned := make(map[LedgerType][]LedgerEntry, len(snapshot.entries))
+	for typ, items := range snapshot.entries {
+		cloned[typ] = cloneEntrySlice(items)
+	}
+	return cloned
+}
+
+// AppendAllowlist inserts or updates an allowlist entry.
+func (s *LedgerStore) AppendAllowlist(entry *IPAllowlistEntry, actor string) (*IPAllowlistEntry, error) {
+	if entry == nil {
+		return nil, errors.New("allowlist entry cannot be nil")
+	}
+	if _, _, err := net.ParseCIDR(entry.CIDR); err != nil {
+		if ip := net.ParseIP(entry.CIDR); ip == nil {
+			return nil, fmt.Errorf("invalid CIDR or IP: %w", err)
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	if entry.ID == "" {
+		entry.ID = GenerateID("allow")
+		entry.CreatedAt = now
+	}
+	entry.UpdatedAt = now
+	copied := *entry
+	s.allow[copied.ID] = &copied
+	s.appendAuditLocked(actor, "allowlist_upsert", copied.ID)
+	return &copied, nil
+}
+
+// RemoveAllowlist deletes an entry.
+func (s *LedgerStore) RemoveAllowlist(id string, actor string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.allow[id]; ok {
+		delete(s.allow, id)
+		s.appendAuditLocked(actor, "allowlist_delete", id)
+		return true
+	}
+	return false
+}
+
+// ListAllowlist returns allow entries ordered by creation time.
+func (s *LedgerStore) ListAllowlist() []*IPAllowlistEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*IPAllowlistEntry, 0, len(s.allow))
+	for _, entry := range s.allow {
+		copy := *entry
+		out = append(out, &copy)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	return out
+}
+
+// IsIPAllowed checks whether ipStr is within the allowlist. Empty allowlist permits all.
+func (s *LedgerStore) IsIPAllowed(ipStr string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.allow) == 0 {
+		return true
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, entry := range s.allow {
+		if _, network, err := net.ParseCIDR(entry.CIDR); err == nil {
+			if network.Contains(ip) {
+				return true
+			}
+			continue
+		}
+		if ip.Equal(net.ParseIP(entry.CIDR)) {
+			return true
+		}
+	}
+	return false
+}
+
+// AppendAudit adds an audit log entry.
+func (s *LedgerStore) appendAuditLocked(actor, action, details string) {
+	entry := &AuditLogEntry{
+		ID:        GenerateID("audit"),
+		Actor:     actor,
+		Action:    action,
+		Details:   details,
+		CreatedAt: time.Now().UTC(),
+	}
+	if n := len(s.audits); n > 0 {
+		entry.PrevHash = s.audits[n-1].Hash
+	}
+	entry.Hash = computeAuditHash(entry)
+	s.audits = append(s.audits, entry)
+}
+
+// ListAudits returns stored audit entries.
+func (s *LedgerStore) ListAudits() []*AuditLogEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*AuditLogEntry, len(s.audits))
+	for i, entry := range s.audits {
+		copy := *entry
+		out[i] = &copy
+	}
+	return out
+}
+
+func computeAuditHash(entry *AuditLogEntry) string {
+	payload := fmt.Sprintf("%s|%s|%s|%s", entry.PrevHash, entry.Action, entry.Details, entry.CreatedAt.Format(time.RFC3339Nano))
+	sum := sha256.Sum256([]byte(payload))
+	return base64.RawStdEncoding.EncodeToString(sum[:])
+}
+
+// VerifyAuditChain recomputes the hashes and ensures the chain remains valid.
+func (s *LedgerStore) VerifyAuditChain() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	prev := ""
+	for _, entry := range s.audits {
+		expected := computeAuditHash(&AuditLogEntry{
+			PrevHash:  prev,
+			Action:    entry.Action,
+			Details:   entry.Details,
+			CreatedAt: entry.CreatedAt,
+		})
+		if entry.Hash != expected {
+			return false
+		}
+		prev = entry.Hash
+	}
+	return true
+}
+
+// UpsertUser ensures a user exists.
+func (s *LedgerStore) UpsertUser(username string) *User {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getOrCreateUserLocked(username)
+}
+
+func (s *LedgerStore) getOrCreateUserLocked(username string) *User {
+	username = strings.ToLower(username)
+	if user, ok := s.users[username]; ok {
+		return user
+	}
+	user := &User{
+		Username:  username,
+		Devices:   make(map[string]*UserDevice),
+		Roles:     []string{"admin"},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	s.users[username] = user
+	return user
+}
+
+// StartEnrollment registers a new enrollment challenge.
+func (s *LedgerStore) StartEnrollment(username, deviceName string, publicKey []byte) (*Enrollment, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("public key must be %d bytes", ed25519.PublicKeySize)
+	}
+	user := s.UpsertUser(username)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	deviceID := GenerateID("device")
+	nonce := GenerateID("nonce")
+	enrollment := &Enrollment{
+		Username:   user.Username,
+		DeviceID:   deviceID,
+		DeviceName: deviceName,
+		Nonce:      nonce,
+		PublicKey:  append([]byte(nil), publicKey...),
+		CreatedAt:  time.Now().UTC(),
+	}
+	s.pendingEnrollments[enrollmentKey(user.Username, deviceID)] = enrollment
+	return enrollment, nil
+}
+
+// CompleteEnrollment verifies the signature and stores the device.
+func (s *LedgerStore) CompleteEnrollment(username, deviceID, nonce string, signature []byte, fingerprint string) (*UserDevice, error) {
+	key := enrollmentKey(username, deviceID)
+	s.mu.Lock()
+	enrollment, ok := s.pendingEnrollments[key]
+	if !ok || enrollment.Nonce != nonce {
+		s.mu.Unlock()
+		return nil, ErrEnrollmentNotFound
+	}
+	delete(s.pendingEnrollments, key)
+	s.mu.Unlock()
+
+	if len(signature) != ed25519.SignatureSize {
+		return nil, ErrSignatureInvalid
+	}
+	if !ed25519.Verify(ed25519.PublicKey(enrollment.PublicKey), []byte(enrollment.Nonce), signature) {
+		return nil, ErrSignatureInvalid
+	}
+	fingerprintSum := s.hashFingerprint(fingerprint)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	user := s.getOrCreateUserLocked(username)
+	device := &UserDevice{
+		ID:             deviceID,
+		Name:           enrollment.DeviceName,
+		PublicKey:      append([]byte(nil), enrollment.PublicKey...),
+		FingerprintSum: fingerprintSum,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	user.Devices[deviceID] = device
+	user.UpdatedAt = time.Now().UTC()
+	s.appendAuditLocked(username, "device_enrolled", deviceID)
+	return device, nil
+}
+
+// RequestLoginNonce generates a login nonce for the given device.
+func (s *LedgerStore) RequestLoginNonce(username, deviceID string) (*LoginChallenge, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	username = strings.ToLower(username)
+	user, ok := s.users[username]
+	if !ok {
+		return nil, fmt.Errorf("user %s not found", username)
+	}
+	if _, ok := user.Devices[deviceID]; !ok {
+		return nil, fmt.Errorf("device %s not enrolled", deviceID)
+	}
+	challenge := &LoginChallenge{
+		Username:  username,
+		DeviceID:  deviceID,
+		Nonce:     GenerateID("nonce"),
+		CreatedAt: time.Now().UTC(),
+	}
+	s.loginChallenges[enrollmentKey(username, deviceID)] = challenge
+	return challenge, nil
+}
+
+// ValidateLogin verifies the submitted signature, fingerprint, and IP allowlist.
+func (s *LedgerStore) ValidateLogin(username, deviceID, nonce string, signature []byte, fingerprint, ip string) (*User, error) {
+	key := enrollmentKey(username, deviceID)
+	s.mu.Lock()
+	challenge, ok := s.loginChallenges[key]
+	if !ok || challenge.Nonce != nonce {
+		s.mu.Unlock()
+		return nil, ErrLoginChallengeNotFound
+	}
+	delete(s.loginChallenges, key)
+	user, ok := s.users[strings.ToLower(username)]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("user %s not found", username)
+	}
+	device, ok := user.Devices[deviceID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("device %s not enrolled", deviceID)
+	}
+	s.mu.Unlock()
+
+	if !ed25519.Verify(ed25519.PublicKey(device.PublicKey), []byte(challenge.Nonce), signature) {
+		return nil, ErrSignatureInvalid
+	}
+	if s.hashFingerprint(fingerprint) != device.FingerprintSum {
+		return nil, ErrFingerprintMismatch
+	}
+	if !s.IsIPAllowed(ip) {
+		return nil, ErrIPNotAllowed
+	}
+	s.appendAuditLocked(username, "login", deviceID)
+	return user, nil
+}
+
+func (s *LedgerStore) hashFingerprint(value string) string {
+	mac := hmac.New(sha256.New, s.fingerprintSecret)
+	mac.Write([]byte(value))
+	return base64.RawStdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// GetUser returns a user by username.
+func (s *LedgerStore) GetUser(username string) (*User, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	user, ok := s.users[strings.ToLower(username)]
+	if !ok {
+		return nil, false
+	}
+	copy := *user
+	copy.Devices = make(map[string]*UserDevice, len(user.Devices))
+	for id, device := range user.Devices {
+		dup := *device
+		dup.PublicKey = append([]byte(nil), device.PublicKey...)
+		copy.Devices[id] = &dup
+	}
+	copy.Roles = append([]string{}, user.Roles...)
+	return &copy, true
+}
+
+func normaliseStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/models/store_test.go
+++ b/internal/models/store_test.go
@@ -1,0 +1,79 @@
+package models
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+)
+
+func TestLedgerStoreUndoRedo(t *testing.T) {
+	store := NewLedgerStore([]byte("secret"))
+
+	if store.CanUndo() {
+		t.Fatalf("expected no undo available initially")
+	}
+
+	if _, err := store.CreateEntry(LedgerTypeDevice, LedgerEntry{Name: "Gateway"}, "tester"); err != nil {
+		t.Fatalf("create entry failed: %v", err)
+	}
+	if !store.CanUndo() {
+		t.Fatalf("expected undo available after create")
+	}
+	if got := len(store.ListEntries(LedgerTypeDevice)); got != 1 {
+		t.Fatalf("expected 1 entry, got %d", got)
+	}
+
+	if err := store.Undo(); err != nil {
+		t.Fatalf("undo failed: %v", err)
+	}
+	if store.CanRedo() == false {
+		t.Fatalf("expected redo available after undo")
+	}
+	if got := len(store.ListEntries(LedgerTypeDevice)); got != 0 {
+		t.Fatalf("expected entries cleared after undo, got %d", got)
+	}
+	if err := store.Redo(); err != nil {
+		t.Fatalf("redo failed: %v", err)
+	}
+	if got := len(store.ListEntries(LedgerTypeDevice)); got != 1 {
+		t.Fatalf("expected entries restored after redo, got %d", got)
+	}
+}
+
+func TestLedgerStoreEnrollmentAndLogin(t *testing.T) {
+	store := NewLedgerStore([]byte("secret"))
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	enrollment, err := store.StartEnrollment("alice", "Laptop", pub)
+	if err != nil {
+		t.Fatalf("start enrollment: %v", err)
+	}
+	sig := ed25519.Sign(priv, []byte(enrollment.Nonce))
+	if _, err := store.CompleteEnrollment("alice", enrollment.DeviceID, enrollment.Nonce, sig, "fingerprint-1"); err != nil {
+		t.Fatalf("complete enrollment: %v", err)
+	}
+	if _, err := store.AppendAllowlist(&IPAllowlistEntry{CIDR: "0.0.0.0/0", Label: "any"}, "system"); err != nil {
+		t.Fatalf("allowlist: %v", err)
+	}
+
+	challenge, err := store.RequestLoginNonce("alice", enrollment.DeviceID)
+	if err != nil {
+		t.Fatalf("request nonce: %v", err)
+	}
+	loginSig := ed25519.Sign(priv, []byte(challenge.Nonce))
+	if _, err := store.ValidateLogin("alice", enrollment.DeviceID, challenge.Nonce, loginSig, "fingerprint-1", "192.168.1.10"); err != nil {
+		t.Fatalf("validate login: %v", err)
+	}
+
+	challenge2, err := store.RequestLoginNonce("alice", enrollment.DeviceID)
+	if err != nil {
+		t.Fatalf("request nonce 2: %v", err)
+	}
+	loginSig2 := ed25519.Sign(priv, []byte(challenge2.Nonce))
+	if _, err := store.ValidateLogin("alice", enrollment.DeviceID, challenge2.Nonce, loginSig2, "fingerprint-bad", "192.168.1.10"); err == nil {
+		t.Fatalf("expected fingerprint mismatch error")
+	}
+}

--- a/internal/xlsx/xlsx.go
+++ b/internal/xlsx/xlsx.go
@@ -1,0 +1,402 @@
+package xlsx
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Workbook represents a simplified XLSX workbook with inline string cells.
+type Workbook struct {
+	Sheets []Sheet
+}
+
+// Sheet represents a sheet with ordered rows and columns.
+type Sheet struct {
+	Name string
+	Rows [][]string
+}
+
+// Encode produces an XLSX binary containing the workbook data.
+func Encode(wb Workbook) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+
+	if err := writeFile(zw, "[Content_Types].xml", contentTypesXML(len(wb.Sheets))); err != nil {
+		return nil, err
+	}
+	if err := writeFile(zw, "_rels/.rels", rootRelsXML); err != nil {
+		return nil, err
+	}
+	if err := writeFile(zw, "xl/workbook.xml", workbookXML(wb)); err != nil {
+		return nil, err
+	}
+	if err := writeFile(zw, "xl/_rels/workbook.xml.rels", workbookRelsXML(len(wb.Sheets))); err != nil {
+		return nil, err
+	}
+	for i, sheet := range wb.Sheets {
+		name := fmt.Sprintf("xl/worksheets/sheet%d.xml", i+1)
+		if err := writeFile(zw, name, sheetXML(sheet)); err != nil {
+			return nil, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeFile(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func contentTypesXML(sheetCount int) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`)
+	b.WriteString(`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>`)
+	b.WriteString(`<Default Extension="xml" ContentType="application/xml"/>`)
+	b.WriteString(`<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>`)
+	for i := 1; i <= sheetCount; i++ {
+		b.WriteString(fmt.Sprintf(`<Override PartName="/xl/worksheets/sheet%d.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`, i))
+	}
+	b.WriteString(`</Types>`)
+	return []byte(b.String())
+}
+
+var rootRelsXML = []byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+	`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+	`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>` +
+	`</Relationships>`)
+
+func workbookXML(wb Workbook) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" `)
+	b.WriteString(`xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">`)
+	b.WriteString(`<sheets>`)
+	for i, sheet := range wb.Sheets {
+		b.WriteString(fmt.Sprintf(`<sheet name="%s" sheetId="%d" r:id="rId%d"/>`, escapeXML(sheet.Name), i+1, i+1))
+	}
+	b.WriteString(`</sheets></workbook>`)
+	return []byte(b.String())
+}
+
+func workbookRelsXML(sheetCount int) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`)
+	for i := 1; i <= sheetCount; i++ {
+		b.WriteString(fmt.Sprintf(`<Relationship Id="rId%d" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet%d.xml"/>`, i, i))
+	}
+	b.WriteString(`</Relationships>`)
+	return []byte(b.String())
+}
+
+func sheetXML(sheet Sheet) []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">`)
+	b.WriteString(`<sheetData>`)
+	for i, row := range sheet.Rows {
+		b.WriteString(fmt.Sprintf(`<row r="%d">`, i+1))
+		for j, cell := range row {
+			if cell == "" {
+				continue
+			}
+			ref := cellRef(i, j)
+			b.WriteString(fmt.Sprintf(`<c r="%s" t="inlineStr"><is><t>%s</t></is></c>`, ref, escapeXML(cell)))
+		}
+		b.WriteString(`</row>`)
+	}
+	b.WriteString(`</sheetData></worksheet>`)
+	return []byte(b.String())
+}
+
+func escapeXML(s string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"\"", "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(s)
+}
+
+func cellRef(row, col int) string {
+	return columnName(col) + strconv.Itoa(row+1)
+}
+
+func columnName(index int) string {
+	name := ""
+	for index >= 0 {
+		rem := index % 26
+		name = string(rune('A'+rem)) + name
+		index = index/26 - 1
+	}
+	return name
+}
+
+// Decode parses a simplified XLSX workbook into memory.
+func Decode(data []byte) (Workbook, error) {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return Workbook{}, err
+	}
+	files := make(map[string]*zip.File)
+	for _, f := range reader.File {
+		files[path.Clean(f.Name)] = f
+	}
+
+	workbookFile, ok := files["xl/workbook.xml"]
+	if !ok {
+		return Workbook{}, fmt.Errorf("workbook.xml missing")
+	}
+	workbookData, err := readZipFile(workbookFile)
+	if err != nil {
+		return Workbook{}, err
+	}
+	rels := map[string]string{}
+	if relFile, ok := files["xl/_rels/workbook.xml.rels"]; ok {
+		relData, err := readZipFile(relFile)
+		if err != nil {
+			return Workbook{}, err
+		}
+		rels = parseRelationships(relData)
+	}
+	sharedStrings := []string{}
+	if ssFile, ok := files["xl/sharedStrings.xml"]; ok {
+		ssData, err := readZipFile(ssFile)
+		if err != nil {
+			return Workbook{}, err
+		}
+		sharedStrings = parseSharedStrings(ssData)
+	}
+
+	type sheetInfo struct {
+		Name string `xml:"name,attr"`
+		ID   string `xml:"sheetId,attr"`
+		RID  string `xml:"id,attr"`
+	}
+	type workbookDef struct {
+		Sheets []sheetInfo `xml:"sheets>sheet"`
+	}
+	var wbDef workbookDef
+	if err := xml.Unmarshal(workbookData, &wbDef); err != nil {
+		return Workbook{}, err
+	}
+	workbook := Workbook{}
+	for _, info := range wbDef.Sheets {
+		target := rels[info.RID]
+		if target == "" {
+			target = fmt.Sprintf("worksheets/sheet%s.xml", info.ID)
+		}
+		sheetFile, ok := files[path.Clean("xl/"+target)]
+		if !ok {
+			continue
+		}
+		sheetData, err := readZipFile(sheetFile)
+		if err != nil {
+			return Workbook{}, err
+		}
+		sheet := parseSheet(sheetData, sharedStrings)
+		sheet.Name = info.Name
+		workbook.Sheets = append(workbook.Sheets, sheet)
+	}
+	return workbook, nil
+}
+
+func readZipFile(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+func parseRelationships(data []byte) map[string]string {
+	type rel struct {
+		ID     string `xml:"Id,attr"`
+		Target string `xml:"Target,attr"`
+	}
+	type doc struct {
+		Relationships []rel `xml:"Relationship"`
+	}
+	var d doc
+	_ = xml.Unmarshal(data, &d)
+	result := make(map[string]string, len(d.Relationships))
+	for _, r := range d.Relationships {
+		result[r.ID] = r.Target
+	}
+	return result
+}
+
+func parseSharedStrings(data []byte) []string {
+	type si struct {
+		Text string `xml:"t"`
+	}
+	type sst struct {
+		Items []si `xml:"si"`
+	}
+	var doc sst
+	_ = xml.Unmarshal(data, &doc)
+	out := make([]string, len(doc.Items))
+	for i, item := range doc.Items {
+		out[i] = item.Text
+	}
+	return out
+}
+
+func parseSheet(data []byte, sharedStrings []string) Sheet {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	rows := [][]string{}
+	currentRow := -1
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+		switch elem := token.(type) {
+		case xml.StartElement:
+			if elem.Name.Local == "row" {
+				currentRow++
+				rows = append(rows, []string{})
+			}
+			if elem.Name.Local == "c" {
+				var cell struct {
+					R string `xml:"r,attr"`
+					T string `xml:"t,attr"`
+				}
+				cell.R = attr(elem.Attr, "r")
+				cell.T = attr(elem.Attr, "t")
+				col := columnIndex(cell.R)
+				for len(rows[currentRow]) <= col {
+					rows[currentRow] = append(rows[currentRow], "")
+				}
+				value := readCellValue(decoder)
+				if cell.T == "s" {
+					idx, _ := strconv.Atoi(value)
+					if idx >= 0 && idx < len(sharedStrings) {
+						value = sharedStrings[idx]
+					}
+				}
+				rows[currentRow][col] = value
+			}
+		}
+	}
+	for i := range rows {
+		trim := len(rows[i])
+		for trim > 0 && rows[i][trim-1] == "" {
+			trim--
+		}
+		rows[i] = rows[i][:trim]
+	}
+	return Sheet{Rows: rows}
+}
+
+func attr(attrs []xml.Attr, name string) string {
+	for _, attr := range attrs {
+		if attr.Name.Local == name {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+func readCellValue(decoder *xml.Decoder) string {
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		switch elem := token.(type) {
+		case xml.StartElement:
+			if elem.Name.Local == "v" || elem.Name.Local == "t" {
+				var value string
+				_ = decoder.DecodeElement(&value, &elem)
+				return value
+			}
+			if elem.Name.Local == "is" {
+				var inline struct {
+					Text string `xml:"t"`
+				}
+				_ = decoder.DecodeElement(&inline, &elem)
+				return inline.Text
+			}
+		case xml.EndElement:
+			if elem.Name.Local == "c" {
+				return ""
+			}
+		}
+	}
+}
+
+func columnIndex(ref string) int {
+	ref = strings.ToUpper(ref)
+	letters := ""
+	for _, r := range ref {
+		if r >= 'A' && r <= 'Z' {
+			letters += string(r)
+		} else {
+			break
+		}
+	}
+	if letters == "" {
+		return 0
+	}
+	index := 0
+	for _, r := range letters {
+		index = index*26 + int(r-'A'+1)
+	}
+	return index - 1
+}
+
+// SheetByName retrieves a sheet by name.
+func (wb Workbook) SheetByName(name string) (Sheet, bool) {
+	for _, sheet := range wb.Sheets {
+		if strings.EqualFold(sheet.Name, name) {
+			return sheet, true
+		}
+	}
+	return Sheet{}, false
+}
+
+// SortSheets sorts sheets by provided order, keeping unspecified ones after.
+func (wb *Workbook) SortSheets(order []string) {
+	lookup := make(map[string]int, len(order))
+	for i, name := range order {
+		lookup[strings.ToLower(name)] = i
+	}
+	sort.SliceStable(wb.Sheets, func(i, j int) bool {
+		a := strings.ToLower(wb.Sheets[i].Name)
+		b := strings.ToLower(wb.Sheets[j].Name)
+		ia, oka := lookup[a]
+		ib, okb := lookup[b]
+		switch {
+		case oka && okb:
+			return ia < ib
+		case oka:
+			return true
+		case okb:
+			return false
+		default:
+			return a < b
+		}
+	})
+}

--- a/internal/xlsx/xlsx_test.go
+++ b/internal/xlsx/xlsx_test.go
@@ -1,0 +1,31 @@
+package xlsx
+
+import "testing"
+
+func TestEncodeDecodeWorkbook(t *testing.T) {
+	wb := Workbook{Sheets: []Sheet{{Name: "Devices", Rows: [][]string{{"ID", "Name"}, {"1", "Router"}}}}}
+	data, err := Encode(wb)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	decoded, err := Decode(data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(decoded.Sheets) != 1 {
+		t.Fatalf("expected 1 sheet, got %d", len(decoded.Sheets))
+	}
+	if decoded.Sheets[0].Name != "Devices" {
+		t.Fatalf("unexpected sheet name: %s", decoded.Sheets[0].Name)
+	}
+	if got := decoded.Sheets[0].Rows[1][1]; got != "Router" {
+		t.Fatalf("unexpected cell value: %s", got)
+	}
+}
+
+func TestSheetByName(t *testing.T) {
+	wb := Workbook{Sheets: []Sheet{{Name: "IP"}, {Name: "Matrix"}}}
+	if _, ok := wb.SheetByName("ip"); !ok {
+		t.Fatalf("expected to find sheet by case-insensitive name")
+	}
+}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS devices (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    public_key BYTEA NOT NULL,
+    fingerprint_sum TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, device_id)
+);
+
+CREATE TABLE IF NOT EXISTS ip_allowlists (
+    id SERIAL PRIMARY KEY,
+    label TEXT NOT NULL,
+    cidr TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id SERIAL PRIMARY KEY,
+    actor TEXT NOT NULL,
+    action TEXT NOT NULL,
+    details TEXT,
+    hash TEXT NOT NULL,
+    prev_hash TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO users (username)
+    VALUES ('admin')
+    ON CONFLICT (username) DO NOTHING;
+
+COMMIT;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,638 @@
+openapi: 3.0.3
+info:
+  title: Ledger Backend API
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    LedgerEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        links:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        order:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    LedgerListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerEntry'
+    LedgerReorderRequest:
+      type: object
+      required:
+        - ids
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+    LedgerImportRequest:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: string
+          format: byte
+          description: Base64-encoded XLSX payload
+    AllowlistEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        cidr:
+          type: string
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AllowlistRequest:
+      type: object
+      required:
+        - label
+        - cidr
+      properties:
+        label:
+          type: string
+        cidr:
+          type: string
+        description:
+          type: string
+    AllowlistListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllowlistEntry'
+    AuditEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        actor:
+          type: string
+        action:
+          type: string
+        details:
+          type: string
+        hash:
+          type: string
+        prev_hash:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    AuditListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditEntry'
+    Session:
+      type: object
+      properties:
+        token:
+          type: string
+        username:
+          type: string
+        device_id:
+          type: string
+        issued_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    EnrollmentRequest:
+      type: object
+      required:
+        - username
+        - device_name
+        - public_key
+      properties:
+        username:
+          type: string
+        device_name:
+          type: string
+        public_key:
+          type: string
+          description: Base64-encoded Ed25519 public key
+    EnrollmentResponse:
+      type: object
+      properties:
+        device_id:
+          type: string
+        nonce:
+          type: string
+    EnrollmentCompleteRequest:
+      type: object
+      required:
+        - username
+        - device_id
+        - nonce
+        - signature
+        - fingerprint
+      properties:
+        username:
+          type: string
+        device_id:
+          type: string
+        nonce:
+          type: string
+        signature:
+          type: string
+          description: Base64 signature of the nonce
+        fingerprint:
+          type: string
+          description: Client fingerprint payload
+    NonceRequest:
+      type: object
+      required:
+        - username
+        - device_id
+      properties:
+        username:
+          type: string
+        device_id:
+          type: string
+    NonceResponse:
+      type: object
+      properties:
+        nonce:
+          type: string
+    LoginRequest:
+      type: object
+      required:
+        - username
+        - device_id
+        - nonce
+        - signature
+        - fingerprint
+      properties:
+        username:
+          type: string
+        device_id:
+          type: string
+        nonce:
+          type: string
+        signature:
+          type: string
+        fingerprint:
+          type: string
+    HistoryStatus:
+      type: object
+      properties:
+        undo:
+          type: boolean
+        redo:
+          type: boolean
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service status
+          content:
+            application/json:
+              schema:
+                type: object
+  /auth/enroll-request:
+    post:
+      summary: Initiate device enrollment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentRequest'
+      responses:
+        '200':
+          description: Enrollment nonce issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentResponse'
+  /auth/enroll-complete:
+    post:
+      summary: Complete device enrollment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentCompleteRequest'
+      responses:
+        '200':
+          description: Device enrolled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  device_id:
+                    type: string
+                  fingerprint_sum:
+                    type: string
+  /auth/request-nonce:
+    post:
+      summary: Request login nonce
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NonceRequest'
+      responses:
+        '200':
+          description: Nonce issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonceResponse'
+  /auth/login:
+    post:
+      summary: Authenticate a device
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Session issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+  /api/v1/ledgers/{type}:
+    get:
+      summary: List ledger entries
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Ledger list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerListResponse'
+    post:
+      summary: Create ledger entry
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerEntry'
+      responses:
+        '200':
+          description: Entry created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerEntry'
+  /api/v1/ledgers/{type}/{id}:
+    put:
+      summary: Update a ledger entry
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerEntry'
+      responses:
+        '200':
+          description: Entry updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerEntry'
+    delete:
+      summary: Delete a ledger entry
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Entry deleted
+  /api/v1/ledgers/{type}/reorder:
+    post:
+      summary: Reorder ledger entries
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerReorderRequest'
+      responses:
+        '200':
+          description: New ordering returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerListResponse'
+  /api/v1/ledgers/{type}/import:
+    post:
+      summary: Import a single ledger from XLSX
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [ips, devices, personnel, systems]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerImportRequest'
+      responses:
+        '200':
+          description: Ledger replaced
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerListResponse'
+  /api/v1/ledgers/export:
+    get:
+      summary: Export all ledgers to XLSX
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: XLSX workbook
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+  /api/v1/ledgers/import:
+    post:
+      summary: Import all ledgers from XLSX
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerImportRequest'
+      responses:
+        '200':
+          description: Import accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /api/v1/ledger-cartesian:
+    get:
+      summary: Derived ledger matrix
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Cartesian rows
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rows:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: string
+  /api/v1/ip-allowlist:
+    get:
+      summary: List allowlist entries
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Allowlist entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllowlistListResponse'
+    post:
+      summary: Add allowlist entry
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllowlistRequest'
+      responses:
+        '200':
+          description: Entry stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllowlistEntry'
+  /api/v1/ip-allowlist/{id}:
+    put:
+      summary: Update allowlist entry
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllowlistRequest'
+      responses:
+        '200':
+          description: Entry updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllowlistEntry'
+    delete:
+      summary: Delete allowlist entry
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Entry removed
+  /api/v1/history/undo:
+    post:
+      summary: Undo previous mutation
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Undo successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /api/v1/history/redo:
+    post:
+      summary: Redo next mutation
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Redo successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /api/v1/history:
+    get:
+      summary: History availability
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Undo/redo availability
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryStatus'
+  /api/v1/audit:
+    get:
+      summary: List audit logs
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Audit log entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditListResponse'
+  /api/v1/audit/verify:
+    get:
+      summary: Verify audit chain
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Chain verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified:
+                    type: boolean

--- a/third_party/gin/gin.go
+++ b/third_party/gin/gin.go
@@ -1,0 +1,410 @@
+package gin
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// HandlerFunc defines the handler used by gin.
+type HandlerFunc func(*Context)
+
+// H is a shortcut for creating JSON responses.
+type H map[string]any
+
+// Engine stores registered routes and middleware.
+type Engine struct {
+	routes      []*route
+	middlewares []HandlerFunc
+	pool        sync.Pool
+}
+
+// RouterGroup represents a route grouping with shared middleware and prefix.
+type RouterGroup struct {
+	engine   *Engine
+	basePath string
+	handlers []HandlerFunc
+}
+
+type route struct {
+	method   string
+	path     string
+	handlers []HandlerFunc
+	parts    []pathPart
+}
+
+type pathPart struct {
+	value string
+	param bool
+}
+
+// Context carries request-scoped values and helpers.
+type Context struct {
+	Writer   http.ResponseWriter
+	Request  *http.Request
+	handlers []HandlerFunc
+	index    int
+	params   map[string]string
+	keys     map[string]any
+	status   int
+	aborted  bool
+}
+
+// Default returns a new Engine with no-op logger and recovery middleware wired.
+func Default() *Engine {
+	e := New()
+	e.Use(Logger(), Recovery())
+	return e
+}
+
+// New creates an Engine instance.
+func New() *Engine {
+	e := &Engine{}
+	e.pool.New = func() any { return &Context{} }
+	return e
+}
+
+// ServeHTTP matches the incoming request against the registered routes.
+func (e *Engine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, rt := range e.routes {
+		if rt.method != r.Method {
+			continue
+		}
+		params, ok := matchPath(rt.parts, r.URL.Path)
+		if !ok {
+			continue
+		}
+		ctx := e.getContext(w, r, params, rt.handlers)
+		ctx.Next()
+		e.putContext(ctx)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// Use appends middleware handlers to the engine.
+func (e *Engine) Use(handlers ...HandlerFunc) {
+	e.middlewares = append(e.middlewares, handlers...)
+}
+
+// Logger provides a placeholder logger middleware.
+func Logger() HandlerFunc { return func(*Context) {} }
+
+// Recovery provides a placeholder recovery middleware.
+func Recovery() HandlerFunc { return func(*Context) {} }
+
+func (e *Engine) addRoute(method, path string, handlers []HandlerFunc) {
+	parts := parsePath(path)
+	combined := append([]HandlerFunc{}, e.middlewares...)
+	combined = append(combined, handlers...)
+	e.routes = append(e.routes, &route{method: method, path: path, handlers: combined, parts: parts})
+}
+
+// Group creates a new router group beneath the engine.
+func (e *Engine) Group(relativePath string, handlers ...HandlerFunc) *RouterGroup {
+	return &RouterGroup{
+		engine:   e,
+		basePath: joinPaths("", relativePath),
+		handlers: handlers,
+	}
+}
+
+func joinPaths(base, relative string) string {
+	if base == "" {
+		base = "/"
+	}
+	if relative == "" {
+		return base
+	}
+	if strings.HasSuffix(base, "/") {
+		base = strings.TrimSuffix(base, "/")
+	}
+	if !strings.HasPrefix(relative, "/") {
+		relative = "/" + relative
+	}
+	return base + relative
+}
+
+func (g *RouterGroup) handle(method, relativePath string, handlers []HandlerFunc) {
+	if g == nil || g.engine == nil {
+		return
+	}
+	path := joinPaths(g.basePath, relativePath)
+	chain := append([]HandlerFunc{}, g.handlers...)
+	chain = append(chain, handlers...)
+	g.engine.addRoute(method, path, chain)
+}
+
+// Use appends middleware to the group.
+func (g *RouterGroup) Use(handlers ...HandlerFunc) {
+	g.handlers = append(g.handlers, handlers...)
+}
+
+func (g *RouterGroup) GET(relativePath string, handlers ...HandlerFunc) {
+	g.handle(http.MethodGet, relativePath, handlers)
+}
+
+func (g *RouterGroup) POST(relativePath string, handlers ...HandlerFunc) {
+	g.handle(http.MethodPost, relativePath, handlers)
+}
+
+func (g *RouterGroup) PUT(relativePath string, handlers ...HandlerFunc) {
+	g.handle(http.MethodPut, relativePath, handlers)
+}
+
+func (g *RouterGroup) DELETE(relativePath string, handlers ...HandlerFunc) {
+	g.handle(http.MethodDelete, relativePath, handlers)
+}
+
+// HTTP verb helpers ---------------------------------------------------------
+
+func (e *Engine) GET(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodGet, path, handlers)
+}
+
+func (e *Engine) POST(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodPost, path, handlers)
+}
+
+func (e *Engine) PUT(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodPut, path, handlers)
+}
+
+func (e *Engine) DELETE(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodDelete, path, handlers)
+}
+
+func (e *Engine) PATCH(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodPatch, path, handlers)
+}
+
+func (e *Engine) OPTIONS(path string, handlers ...HandlerFunc) {
+	e.addRoute(http.MethodOptions, path, handlers)
+}
+
+// Context helpers -----------------------------------------------------------
+
+// Next advances to the next handler in the chain.
+func (c *Context) Next() {
+	c.index++
+	for c.index < len(c.handlers) {
+		handler := c.handlers[c.index]
+		handler(c)
+		c.index++
+		if c.aborted {
+			return
+		}
+	}
+}
+
+// Abort prevents remaining handlers from executing.
+func (c *Context) Abort() {
+	c.aborted = true
+	c.index = len(c.handlers)
+}
+
+// AbortWithStatusJSON aborts the chain and writes a JSON response.
+func (c *Context) AbortWithStatusJSON(code int, obj any) {
+	c.aborted = true
+	c.JSON(code, obj)
+}
+
+// Status sets the HTTP status code on the response writer.
+func (c *Context) Status(code int) {
+	c.status = code
+	if rw, ok := c.Writer.(*responseWriter); ok {
+		rw.WriteHeader(code)
+		return
+	}
+	c.Writer.WriteHeader(code)
+}
+
+// JSON writes a JSON response with the supplied status code.
+func (c *Context) JSON(code int, obj any) {
+	if code == 0 {
+		code = http.StatusOK
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Status(code)
+	enc := json.NewEncoder(c.Writer)
+	_ = enc.Encode(obj)
+}
+
+// ShouldBindJSON unmarshals the request body into obj.
+func (c *Context) ShouldBindJSON(obj any) error {
+	if c.Request == nil || c.Request.Body == nil {
+		return io.EOF
+	}
+	decoder := json.NewDecoder(c.Request.Body)
+	return decoder.Decode(obj)
+}
+
+// BindJSON mirrors gin's BindJSON alias.
+func (c *Context) BindJSON(obj any) error {
+	return c.ShouldBindJSON(obj)
+}
+
+// Param retrieves a path parameter.
+func (c *Context) Param(key string) string {
+	if c.params == nil {
+		return ""
+	}
+	return c.params[key]
+}
+
+// Query fetches a query parameter.
+func (c *Context) Query(key string) string {
+	if c.Request == nil {
+		return ""
+	}
+	return c.Request.URL.Query().Get(key)
+}
+
+// GetHeader retrieves a header value from the incoming request.
+func (c *Context) GetHeader(key string) string {
+	if c.Request == nil {
+		return ""
+	}
+	return c.Request.Header.Get(key)
+}
+
+// DefaultQuery returns the value for key or def if not present.
+func (c *Context) DefaultQuery(key, def string) string {
+	if v := c.Query(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// Set stores a value in the context.
+func (c *Context) Set(key string, value any) {
+	if c.keys == nil {
+		c.keys = make(map[string]any)
+	}
+	c.keys[key] = value
+}
+
+// Get returns a value stored via Set.
+func (c *Context) Get(key string) (any, bool) {
+	if c.keys == nil {
+		return nil, false
+	}
+	v, ok := c.keys[key]
+	return v, ok
+}
+
+// MustGet returns the stored value or panics.
+func (c *Context) MustGet(key string) any {
+	if v, ok := c.Get(key); ok {
+		return v
+	}
+	panic("gin: key not set")
+}
+
+// Helper functions ----------------------------------------------------------
+
+func (e *Engine) getContext(w http.ResponseWriter, r *http.Request, params map[string]string, handlers []HandlerFunc) *Context {
+	ctx := e.pool.Get().(*Context)
+	ctx.Writer = &responseWriter{ResponseWriter: w}
+	ctx.Request = r
+	ctx.params = params
+	ctx.handlers = handlers
+	ctx.index = -1
+	ctx.keys = nil
+	ctx.status = 0
+	ctx.aborted = false
+	return ctx
+}
+
+func (e *Engine) putContext(ctx *Context) {
+	ctx.Writer = nil
+	ctx.Request = nil
+	ctx.handlers = nil
+	ctx.params = nil
+	ctx.keys = nil
+	e.pool.Put(ctx)
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *responseWriter) WriteHeader(statusCode int) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (w *responseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *responseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		if !w.wroteHeader {
+			w.WriteHeader(http.StatusOK)
+		}
+		f.Flush()
+	}
+}
+
+func matchPath(parts []pathPart, rawPath string) (map[string]string, bool) {
+	path := rawPath
+	if path == "" {
+		path = "/"
+	}
+	incoming := splitPath(path)
+	if len(incoming) != len(parts) {
+		return nil, false
+	}
+	params := make(map[string]string)
+	for i, part := range parts {
+		seg := incoming[i]
+		if part.param {
+			params[part.value] = seg
+			continue
+		}
+		if part.value != seg {
+			return nil, false
+		}
+	}
+	return params, true
+}
+
+func parsePath(path string) []pathPart {
+	segments := splitPath(path)
+	parts := make([]pathPart, len(segments))
+	for i, seg := range segments {
+		if strings.HasPrefix(seg, ":") {
+			parts[i] = pathPart{value: strings.TrimPrefix(seg, ":"), param: true}
+			continue
+		}
+		parts[i] = pathPart{value: seg}
+	}
+	return parts
+}
+
+func splitPath(path string) []string {
+	if path == "" || path == "/" {
+		return []string{""}
+	}
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return []string{""}
+	}
+	parts := strings.Split(trimmed, "/")
+	for i, p := range parts {
+		if decoded, err := url.PathUnescape(p); err == nil {
+			parts[i] = decoded
+		}
+	}
+	return parts
+}

--- a/third_party/gin/go.mod
+++ b/third_party/gin/go.mod
@@ -1,0 +1,3 @@
+module github.com/gin-gonic/gin
+
+go 1.22


### PR DESCRIPTION
## Summary
- replace the crypto/rand-backed identifier generator with a pre-seeded math/rand token builder
- guard the shared generator with a mutex and reusable alphabet so ID creation keeps working in entropy-starved environments

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbca0d58288329b452b0e968d2652c